### PR TITLE
Pipe FD[] Macro updated

### DIFF
--- a/inc/defines.h
+++ b/inc/defines.h
@@ -35,11 +35,18 @@ struct s_global
 # define SH_WORD	"SHLDEEP"
 
 // --/ Error messages
+
 # define MEMORY_ERROR	"ba.sh: Error trying to allocate memory"
 
 // ---/ Tokenizer
+
 # define WILDCARD_ON 	1
 # define WILDCARD_OFF 	0
+
+// ---/ Pipes
+
+# define PIPE_WR 1
+# define PIPE_RD 0
 
 // ---/ Type of operators between commands
 

--- a/src/executor/executor.c
+++ b/src/executor/executor.c
@@ -126,9 +126,9 @@ static int	set_pipe(t_node	*node, t_env *env_list)
 	fd_out = STDOUT_FILENO;
 	fd_in = STDIN_FILENO;
 	if (node->operator == TPIP)
-		fd_out = node->fd[STDOUT_FILENO];
+		fd_out = node->fd[PIPE_WR];
 	if (is_post_op(node, TPIP))
-		fd_in = node->prev->fd[STDIN_FILENO];
+		fd_in = node->prev->fd[PIPE_RD];
 	if (dup2(fd_out, STDOUT_FILENO) < 0 || (dup2(fd_in, STDIN_FILENO) < 0))
 		err = print_error(NULL, 0, 1);
 	if (!err && node->redirects && prepare_redirect(node->redirects, env_list))


### PR DESCRIPTION
Vamoooooos, solo ne cambiado las macros para poder escribir fd[PIPE_RD] y fd[PIPE_WR] y queda todo más legible, pero a nivel de funcionamiento no ha cmabiado nada. Pasa mpanic completo.